### PR TITLE
ppc64le sync mkconfig to disk (#1212114)

### DIFF
--- a/util/grub-mkconfig.in
+++ b/util/grub-mkconfig.in
@@ -293,3 +293,12 @@ fi
 
 gettext "done" >&2
 echo >&2
+
+# make sure changes make it to the disk.
+# if /boot is a mountpoint, force the meta data on disk
+# to by-pass writeback delay.
+# PPC64LE-only to deal with Petitboot issues
+ARCH=$(uname -m)
+if [ "${ARCH}" = "ppc64le" ]; then
+    sync && mountpoint -q /boot &&fsfreeze -f /boot && fsfreeze -u /boot
+fi


### PR DESCRIPTION
If creating a new grub2 entry using grub2-mkconfig, the entry is not
immediately sync'd to disk.  If a crash happens before the writeback,
the subsequent reboot fails because the grub2.cfg is corrupted.

Address this by forcing all the changes (mainly the fs meta data) to disk
before finishing the grub2 conf changes.

Tested by 'grub2-mkconfig -o /etc/grub22.cfg; echo c > /proc/sysrq-trigger'.

Before, the machine would panic and on reboot be stuck without a grub.cfg
to read.  After, works as expected.

Resolves: rhbz#1212114