### PR TITLE
Failed config now returns exit code (#1252311)

### DIFF
--- a/util/grub-mkconfig.in
+++ b/util/grub-mkconfig.in
@@ -281,6 +281,7 @@ Ensure that there are no errors in /etc/default/grub
 and /etc/grub.d/* files or please file a bug report with
 %s file attached." "${grub_cfg}.new" >&2
     echo >&2
+    exit 1
   else
     # none of the children aborted with error, install the new grub.cfg
     cat ${grub_cfg}.new > ${grub_cfg}


### PR DESCRIPTION
Grub would notify the user if the new config was invalid, however, it
did not exit properly with exit code 1. Added the proper exit code.

Resolves: rhbz#1252311