### PR TITLE
Warn if grub password will not be read (#1290803)

### DIFF
--- a/util/grub-setpassword.in
+++ b/util/grub-setpassword.in
@@ -121,3 +121,8 @@ fi
 install -m 0600 /dev/null "${grubdir}/user.cfg" 2>/dev/null || :
 chmod 0600 "${grubdir}/user.cfg" 2>/dev/null || :
 echo "GRUB2_PASSWORD=${MYPASS}" > "${grubdir}/user.cfg"
+
+if ! grep -q "^### BEGIN /etc/grub.d/01_users ###$" "${grubdir}/grub.cfg"; then
+    echo "WARNING: The current configuration lacks password support!"
+    echo "Update your configuration with @grub_mkconfig@ to support this feature."
+fi


### PR DESCRIPTION
It is possible for a system to have never run grub-mkconfig and add the
section that reads the user.cfg file which contains a user set GRUB
password. Users in that scenario will now be warned that grub-mkconfig
must be run prior to their newly set password taking effect.

Resolves: rhbz#1290803