### PR TITLE
Clean up grub-setpassword documentation (#1290799)

### DIFF
--- a/util/grub-setpassword.8
+++ b/util/grub-setpassword.8
@@ -19,7 +19,7 @@ Display program usage and exit.
 -v, --version
 Display the current version.
 .TP
--o, --output[=\fIDIRECTORY PATH\fR]
+-o, --output=<\fIDIRECTORY\fR>
 Choose the file path to which user.cfg will be written.
 
 .SH SEE ALSO

--- a/util/grub-setpassword.in
+++ b/util/grub-setpassword.in
@@ -16,15 +16,14 @@ grub_mkpasswd="${bindir}/@grub_mkpasswd_pbkdf2@"
 # Print the usage.
 usage () {
     cat <<EOF
-Usage: $0 [OPTION] [SOURCE]
-Run GRUB script in a Qemu instance.
-
-  -h, --help              print this message and exit
-  -v, --version           print the version information and exit
-  -o, --output_path       choose a custom output path for user.cfg
-
+Usage: $0 [OPTION]
 $0 prompts the user to set a password on the grub bootloader. The password
-is written to a file named user.cfg.
+is written to a file named user.cfg which lives in the GRUB directory
+located by default at ${grubdir}.
+
+  -h, --help                     print this message and exit
+  -v, --version                  print the version information and exit
+  -o, --output_path <DIRECTORY>  put user.cfg in a user-selected directory
 
 Report bugs at https://bugzilla.redhat.com.
 EOF


### PR DESCRIPTION
The output for --help had some errors. Corrected those and polished the
text to be a little easier to follow. Carried verbage over to man page
to maintain internal consistency.

Resolves: rhbz#1290799