### PR TITLE
Fix locale issue in grub-setpassword (#1294243)

### DIFF
--- a/util/grub-setpassword.in
+++ b/util/grub-setpassword.in
@@ -105,7 +105,7 @@ getpass() {
     P1="$1" && shift
 
     ( echo ${P0} ; echo ${P1} ) | \
-        ${grub_mkpasswd} | \
+        LC_ALL=C ${grub_mkpasswd} | \
         grep -v '[eE]nter password:' | \
         sed -e "s/PBKDF2 hash of your password is //"
 }


### PR DESCRIPTION
A shell substitution was expecting non-translated output to grab the
hashed password and put it in the user.cfg file. Modified code to force
the generic C locale when this particular piece of code is run.

Resolves: rhbz#1294243