### PR TITLE
ppc64le has no separate /boot mount (#1261926)

### DIFF
--- a/util/grub-mkconfig.in
+++ b/util/grub-mkconfig.in
@@ -294,12 +294,3 @@ fi
 
 gettext "done" >&2
 echo >&2
-
-# make sure changes make it to the disk.
-# if /boot is a mountpoint, force the meta data on disk
-# to by-pass writeback delay.
-# PPC64LE-only to deal with Petitboot issues
-ARCH=$(uname -m)
-if [ "${ARCH}" = "ppc64le" ]; then
-    sync && mountpoint -q /boot &&fsfreeze -f /boot && fsfreeze -u /boot
-fi


### PR DESCRIPTION
The patch for rhbz#1212114 ensures that ppc64le systems sync grub config
changes to disk prior to grub-mkconfig completion and a reboot.

This patch required checking for /boot as its own mount point because
issuing fsfreeze to a root partition is unwise. For administrators who
configured a ppc64le system with no separate /boot partition, the failed
check results in an error message. The file is written and would work
most of the time, however, it also introduces a corner case where the
behavior manifested in rhbz#1212114 could re-appear on these systems.

The system call issued by fsfreeeze is being issued by methods within
the anaconda installer and can be removed from GRUB proper.

Related: rhbz#1315468
Resolves: rhbz#1261926